### PR TITLE
Support for multiple files - input as a file list - using -f flag

### DIFF
--- a/Code2pdf/code2pdf.py
+++ b/Code2pdf/code2pdf.py
@@ -133,6 +133,11 @@ def parse_arg():
         default="default",
         metavar="NAME")
     parser.add_argument(
+        "-f",
+        "--filelist",
+        help="filename contains list of files to be converted",
+        action="store_true")
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -142,9 +147,19 @@ def parse_arg():
 
 def main():
     args = parse_arg()
-    pdf_file = get_output_file(args.filename, args.outputfile)
-    pdf = Code2pdf(args.filename, pdf_file, args.size)
-    pdf.init_print(linenos=args.linenos, style=args.style)
+    if  (args.filelist == False):
+        pdf_file = get_output_file(args.filename, args.outputfile)
+        pdf = Code2pdf(args.filename, pdf_file, args.size)
+        pdf.init_print(linenos=args.linenos, style=args.style)
+    else:
+        with open(args.filename) as filelist:
+            filenames=filelist.read().splitlines()
+        for ifile in filenames:
+            args.filename=ifile
+            pdf_file = get_output_file(args.filename, args.outputfile)
+            pdf = Code2pdf(args.filename, pdf_file, args.size)
+            pdf.init_print(linenos=args.linenos, style=args.style)
+
     return 0
 
 if __name__ == "__main__":

--- a/README
+++ b/README
@@ -51,7 +51,7 @@ Help
 Usage
      
 
-``code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-v] filename [outputfile]``
+``code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-f] [-v] filename [outputfile]``
 
 Options
        
@@ -68,6 +68,7 @@ Options
       -s SIZE, --size SIZE  PDF size. A2,A3,A4,A5 etc
       -S NAME, --style NAME
                             the style name for highlighting. Eg. emacs, vim style etc.
+      -f,--filelist         filename contains list of files to be converted
       -v, --version         show program's version number and exit
 
 Available style types are

--- a/README
+++ b/README
@@ -131,6 +131,8 @@ Contributor
 
 `cclauss <https://github.com/cclauss>`__
 
+`Cibin Joseph <https://github.com/cibinjoseph>`__
+
 License
 ~~~~~~~
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Have an idea to make it better? Go ahead! I will be happy to see a pull request 
 
 [cclauss](https://github.com/cclauss)
 
+[Cibin Joseph](https://github.com/cibinjoseph)
+
 ### License
 ![gpl](https://cloud.githubusercontent.com/assets/7397433/9025904/67008062-3936-11e5-8803-e5b164a0dfc0.png)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ code2pdf -h
 
 ```
 ###### Usage
- ` code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-v] filename [outputfile] `
+ ` code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-f] [-v] filename [outputfile] `
 
 ###### Options
 
@@ -55,6 +55,7 @@ optional arguments:
   -s SIZE, --size SIZE  PDF size. A2,A3,A4,A5 etc
   -S NAME, --style NAME
                         the style name for highlighting. Eg. emacs, vim style etc.
+  -f,--filelist         filename contains list of files to be converted
   -v, --version         show program's version number and exit
 
 ```

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Help
 Usage
      
 
-``code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-v] filename [outputfile]``
+``code2pdf [-h] [-l] [-s SIZE] [-S NAME] [-f] [-v] filename [outputfile]``
 
 Options
        
@@ -74,6 +74,7 @@ Options
       -s SIZE, --size SIZE  PDF size. A2,A3,A4,A5 etc
       -S NAME, --style NAME
                             the style name for highlighting. Eg. emacs, vim style etc.
+      -f,--filelist         filename contains list of files to be converted
       -v, --version         show program's version number and exit
 
 Available style types are

--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,8 @@ Contributor
 
 `cclauss <https://github.com/cclauss>`__
 
+`Cibin Joseph <https://github.com/cibinjoseph>`__
+
 License
 ~~~~~~~
 


### PR DESCRIPTION
Added `-f` or `--filelist` flag that accepts `filename` to be a file containing list of file names to be converted to pdf format.
Usage: `code2pdf -f list_of_files`
where the file `list_of_files` contains file names of files to be converted to pdf format.
Caveats: This will not work if QT pops segfault