### PR TITLE
fixed imports so as to work with Python3

### DIFF
--- a/Code2pdf/__init__.py
+++ b/Code2pdf/__init__.py
@@ -1,1 +1,1 @@
-from code2pdf import main
+from .code2pdf import main

--- a/Code2pdf/code2pdf.py
+++ b/Code2pdf/code2pdf.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
-from PyQt4.QtGui import QTextDocument, QPrinter, QApplication
+from PyQt5.QtGui import QTextDocument
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtPrintSupport import QPrinter
 import argparse
 import logging
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pygments
+pyqt5
 unittest2


### PR DESCRIPTION
This change only works with Python3.
Thus, it might be better to make a branch called `python3` and people can clone that branch if they want to use with python3. 

- Changed PyQt4 to PyQt5
- Changed all the imports
- Fixed `Code2pdf/__init__.py` so that it can be imported

